### PR TITLE
Deliverable/78/fetch related or ancestors

### DIFF
--- a/Lettuce/evaluation/metrics.py
+++ b/Lettuce/evaluation/metrics.py
@@ -268,14 +268,16 @@ class AncestorNamePrecision(InformationRetrievalMetric):
 
         return calc_precision(list(ancestor_names), predicted)
 
+    @property
+    def description(self) -> str:
+        return self._description
+
 
 class RelatedNamePrecision(InformationRetrievalMetric):
     def __init__(
         self,
         connection: Session,
         vocabulary_ids: list[str],
-        min_separation_bound: int = 0,
-        max_separation_bound: int | None = None,
     ) -> None:
         """
         Initialises the Related concept name precision metric
@@ -292,8 +294,6 @@ class RelatedNamePrecision(InformationRetrievalMetric):
             An upper bound for maximum level of separation
         """
         self._description = "Related concept name precision: Calculates precision, where the set of relevant instances is the concept's ancestors"
-        self._min_separation_bound = min_separation_bound
-        self._max_separation_bound = max_separation_bound
         self._connection = connection
         self._vocabulary_ids = vocabulary_ids
 
@@ -306,3 +306,7 @@ class RelatedNamePrecision(InformationRetrievalMetric):
         related_names = set(result[0].concept_name for result in related_concepts)
 
         return calc_precision(list(related_names), predicted)
+
+    @property
+    def description(self) -> str:
+        return self._description

--- a/Lettuce/omop/OMOP_match.py
+++ b/Lettuce/omop/OMOP_match.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from rapidfuzz import fuzz
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from omop.omop_models import build_query
+from omop.omop_queries import text_search_query
 
 from logging import Logger
 from omop.preprocess import preprocess_search_term
@@ -181,7 +181,7 @@ class OMOPMatcher:
         list | None
             A list of search results from the OMOP database if the query comes back with results, otherwise returns None
         """
-        query = build_query(
+        query = text_search_query(
             preprocess_search_term(search_term), vocabulary_id, concept_synonym
         )
         Session = sessionmaker(self.engine)

--- a/Lettuce/omop/db_manager.py
+++ b/Lettuce/omop/db_manager.py
@@ -1,0 +1,23 @@
+from os import environ
+from urllib.parse import quote_plus
+
+from sqlalchemy.engine import URL as db_URL, create_engine
+from sqlalchemy.orm import sessionmaker
+
+DB_HOST = environ["DB_HOST"]
+DB_USER = environ["DB_USER"]
+DB_PASSWORD = quote_plus(environ["DB_PASSWORD"])
+DB_NAME = environ["DB_NAME"]
+DB_PORT = environ["DB_PORT"]
+DB_SCHEMA = environ["DB_SCHEMA"]
+
+url = db_URL.create(
+    drivername="psycopg2",
+    username=DB_USER,
+    password=DB_PASSWORD,
+    host=DB_HOST,
+    port=int(DB_PORT),
+)
+engine = create_engine(url)
+
+Session = sessionmaker

--- a/Lettuce/omop/db_manager.py
+++ b/Lettuce/omop/db_manager.py
@@ -1,7 +1,7 @@
 from os import environ
 from urllib.parse import quote_plus
 
-from sqlalchemy.engine import URL as db_URL, create_engine
+from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import sessionmaker
 
 DB_HOST = environ["DB_HOST"]
@@ -11,13 +11,9 @@ DB_NAME = environ["DB_NAME"]
 DB_PORT = environ["DB_PORT"]
 DB_SCHEMA = environ["DB_SCHEMA"]
 
-url = db_URL.create(
-    drivername="psycopg2",
-    username=DB_USER,
-    password=DB_PASSWORD,
-    host=DB_HOST,
-    port=int(DB_PORT),
+connection_uri = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+engine = create_engine(
+    connection_uri,
 )
-engine = create_engine(url)
 
-Session = sessionmaker
+db_session = sessionmaker(engine)

--- a/Lettuce/omop/omop_models.py
+++ b/Lettuce/omop/omop_models.py
@@ -1,7 +1,6 @@
 from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String, select, func, or_
+from sqlalchemy import Column, Integer, String
 
-from sqlalchemy.sql import Select, text, null
 
 from dotenv import load_dotenv
 from os import environ
@@ -45,80 +44,3 @@ class ConceptSynonym(Base):
 
     def __repr__(self) -> str:
         return super().__repr__()
-
-
-def build_query(
-    search_term: str, vocabulary_id: list[str] | None, concept_synonym: bool
-) -> Select:
-    """
-    Builds an OMOP query to search for concepts
-
-    Uses the ORM models for the concept and concept_synonym tables to build a query
-
-    Parameters
-    ----------
-    search_term: str
-        The term to use when searching the relevant tables for concepts
-    vocabulary_id: list[str]
-        A list of vocabulary_ids in the concepts table. The returned concepts will have one of these vocabulary_ids
-    concept_synonym: str
-        If 'y', then the query is expanded to find matches using the concept_synonym table
-
-    Returns
-    -------
-    Select
-        An SQLAlchemy Select for the desired query
-    """
-    concept_ts_condition = text(
-        "to_tsvector('english', concept_name) @@ to_tsquery('english', :search_term)"
-    )
-    synonym_ts_condition = text(
-        "to_tsvector('english', concept_synonym_name) @@ to_tsquery('english', :search_term)"
-    )
-
-    # Base query
-    query = select(
-        Concept.concept_id,
-        Concept.concept_name,
-        Concept.vocabulary_id,
-        Concept.concept_code,
-    ).where(Concept.standard_concept == "S")
-
-    if vocabulary_id:
-        query = query.where(Concept.vocabulary_id.in_(vocabulary_id))
-
-    if concept_synonym:
-        # Define the synonym matches CTE
-        synonym_matches = (
-            select(
-                ConceptSynonym.concept_id.label("synonym_concept_id"),
-                ConceptSynonym.concept_synonym_name,
-            )
-            .join(Concept, ConceptSynonym.concept_id == Concept.concept_id)
-            .where(Concept.standard_concept == "S")
-            .where(synonym_ts_condition.bindparams(search_term=search_term))
-        )
-        if vocabulary_id:
-            synonym_matches = synonym_matches.where(
-                Concept.vocabulary_id.in_(vocabulary_id)
-            )
-
-        synonym_matches_cte = synonym_matches.cte("synonym_matches")
-
-        # Use the CTE in the main query
-        query = query.add_columns(synonym_matches_cte.c.concept_synonym_name)
-        query = query.outerjoin(
-            synonym_matches_cte,
-            Concept.concept_id == synonym_matches_cte.c.synonym_concept_id,
-        )
-        query = query.where(
-            or_(
-                concept_ts_condition.bindparams(search_term=search_term),
-                Concept.concept_id == synonym_matches_cte.c.synonym_concept_id,
-            )
-        )
-    else:
-        query = query.add_columns(null().label("concept_synonym_name"))
-        query = query.where(concept_ts_condition.bindparams(search_term=search_term))
-
-    return query

--- a/Lettuce/omop/omop_models.py
+++ b/Lettuce/omop/omop_models.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Date, Integer, String
 
 
 from dotenv import load_dotenv
@@ -41,6 +41,27 @@ class ConceptSynonym(Base):
     concept_id = Column(Integer, primary_key=True)
     concept_synonym_name = Column(String)
     language_concept_id = Column(Integer)
+
+    def __repr__(self) -> str:
+        return super().__repr__()
+
+
+class ConceptRelationship(Base):
+    """
+    This class represents an ORM mapping to the OMOP concept_relationship table
+    """
+
+    __tablename__ = "concept_relationship"
+    __table_args__ = {"schema": DB_SCHEMA}
+
+    concept_id_1 = Column(Integer)
+    concept_id_2 = Column(Integer)
+    relationship_id = Column(String)
+    valid_start_date = Column(Date)
+    valid_end_date = Column(Date)
+    invalid_reason = Column(String)
+    # Inserting dummy primary key in ORM layer
+    dummy_primary = Column(Integer, primary_key=True)
 
     def __repr__(self) -> str:
         return super().__repr__()

--- a/Lettuce/omop/omop_models.py
+++ b/Lettuce/omop/omop_models.py
@@ -65,3 +65,19 @@ class ConceptRelationship(Base):
 
     def __repr__(self) -> str:
         return super().__repr__()
+
+
+class ConceptAncestor(Base):
+    """
+    This class represents an ORM mapping to the OMOP concept_ancestor table
+    """
+
+    __tablename__ = "concept_ancestor"
+    __table_args__ = {"schema": DB_SCHEMA}
+
+    ancestor_concept_id = Column(Integer)
+    descendant_concept_id = Column(Integer)
+    min_levels_of_separation = Column(Integer)
+    max_levels_of_separation = Column(Integer)
+
+    dummy_primary = Column(Integer, primary_key=True)

--- a/Lettuce/omop/omop_queries.py
+++ b/Lettuce/omop/omop_queries.py
@@ -1,0 +1,93 @@
+from omop.omop_models import Concept, ConceptSynonym
+
+from sqlalchemy import select, or_
+from sqlalchemy.sql import Select, text, null
+
+
+def text_search_query(
+    search_term: str, vocabulary_id: list[str] | None, concept_synonym: bool
+) -> Select:
+    """
+    Builds an OMOP query to search for concepts
+
+    Uses the ORM models for the concept and concept_synonym tables to build a query
+
+    Parameters
+    ----------
+    search_term: str
+        The term to use when searching the relevant tables for concepts
+    vocabulary_id: list[str]
+        A list of vocabulary_ids in the concepts table. The returned concepts will have one of these vocabulary_ids
+    concept_synonym: str
+        If 'y', then the query is expanded to find matches using the concept_synonym table
+
+    Returns
+    -------
+    Select
+        An SQLAlchemy Select for the desired query
+    """
+    concept_ts_condition = text(
+        "to_tsvector('english', concept_name) @@ to_tsquery('english', :search_term)"
+    )
+    synonym_ts_condition = text(
+        "to_tsvector('english', concept_synonym_name) @@ to_tsquery('english', :search_term)"
+    )
+
+    # Base query
+    query = select(
+        Concept.concept_id,
+        Concept.concept_name,
+        Concept.vocabulary_id,
+        Concept.concept_code,
+    ).where(Concept.standard_concept == "S")
+
+    if vocabulary_id:
+        query = query.where(Concept.vocabulary_id.in_(vocabulary_id))
+
+    if concept_synonym:
+        # Define the synonym matches CTE
+        synonym_matches = (
+            select(
+                ConceptSynonym.concept_id.label("synonym_concept_id"),
+                ConceptSynonym.concept_synonym_name,
+            )
+            .join(Concept, ConceptSynonym.concept_id == Concept.concept_id)
+            .where(Concept.standard_concept == "S")
+            .where(synonym_ts_condition.bindparams(search_term=search_term))
+        )
+        if vocabulary_id:
+            synonym_matches = synonym_matches.where(
+                Concept.vocabulary_id.in_(vocabulary_id)
+            )
+
+        synonym_matches_cte = synonym_matches.cte("synonym_matches")
+
+        # Use the CTE in the main query
+        query = query.add_columns(synonym_matches_cte.c.concept_synonym_name)
+        query = query.outerjoin(
+            synonym_matches_cte,
+            Concept.concept_id == synonym_matches_cte.c.synonym_concept_id,
+        )
+        query = query.where(
+            or_(
+                concept_ts_condition.bindparams(search_term=search_term),
+                Concept.concept_id == synonym_matches_cte.c.synonym_concept_id,
+            )
+        )
+    else:
+        query = query.add_columns(null().label("concept_synonym_name"))
+        query = query.where(concept_ts_condition.bindparams(search_term=search_term))
+
+    return query
+
+
+def query_ancestors_by_name() -> Select: ...
+
+
+def query_ancestors_by_id() -> Select: ...
+
+
+def query_related_by_name() -> Select: ...
+
+
+def query_related_by_id() -> Select: ...

--- a/Lettuce/tests/test_db.py
+++ b/Lettuce/tests/test_db.py
@@ -7,7 +7,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from omop import OMOP_match
-from omop.omop_queries import query_ids_matching_name, query_related_by_name
+from omop.omop_queries import (
+    query_ancestors_by_name,
+    query_descendants_by_name,
+    query_ids_matching_name,
+    query_related_by_name,
+)
 from utils.logging_utils import logger
 
 
@@ -96,5 +101,39 @@ def test_fetch_related_concepts_by_name(db_connection):
 
     assert len(results) > 1
 
-    names = [result[0] for result in results]
+    names = [result[0].concept_name for result in results]
     assert "Sinutab" in names
+
+
+def test_fetch_ancestor_concepts_by_name(db_connection):
+    Session = sessionmaker(db_connection)
+    session = Session()
+
+    query = query_ancestors_by_name("acetaminophen", vocabulary_ids=["RxNorm"])
+    results = session.execute(query).fetchall()
+    session.close()
+
+    assert len(results) > 1
+
+    names = [result[0].concept_name for result in results]
+    assert (
+        "LITTLE REMEDIES NEW BABY ESSENTIALS - acetaminophen, simethicone, zinc oxide kit"
+        in names
+    )
+
+
+def test_fetch_descendant_concepts_by_name(db_connection):
+    Session = sessionmaker(db_connection)
+    session = Session()
+
+    query = query_descendants_by_name("acetaminophen", vocabulary_ids=["RxNorm"])
+    results = session.execute(query).fetchall()
+    session.close()
+
+    assert len(results) > 1
+
+    names = [result[0].concept_name for result in results]
+    assert (
+        "Acetaminophen 0.0934 MG/MG / Ascorbic Acid 0.0333 MG/MG / Pheniramine 0.00333 MG/MG Oral Granules [FERVEX RHUME PARACETAMOL/VITAMINE C] Box of 8"
+        in names
+    )

--- a/Lettuce/tests/test_db.py
+++ b/Lettuce/tests/test_db.py
@@ -122,6 +122,25 @@ def test_fetch_ancestor_concepts_by_name(db_connection):
     )
 
 
+def test_fetch_ancestor_concepts_by_name_with_separation_bounds(db_connection):
+    Session = sessionmaker(db_connection)
+    session = Session()
+
+    query = query_ancestors_by_name(
+        "acetaminophen",
+        vocabulary_ids=["RxNorm"],
+        min_separation_bound=1,
+        max_separation_bound=1,
+    )
+    results = session.execute(query).fetchall()
+    session.close()
+
+    assert len(results) > 1
+
+    names = [result[0].concept_name for result in results]
+    assert "homatropine methylbromide; systemic" in names
+
+
 def test_fetch_descendant_concepts_by_name(db_connection):
     Session = sessionmaker(db_connection)
     session = Session()
@@ -137,3 +156,17 @@ def test_fetch_descendant_concepts_by_name(db_connection):
         "Acetaminophen 0.0934 MG/MG / Ascorbic Acid 0.0333 MG/MG / Pheniramine 0.00333 MG/MG Oral Granules [FERVEX RHUME PARACETAMOL/VITAMINE C] Box of 8"
         in names
     )
+
+
+def test_fetch_descendant_concepts_by_name_with_separation_bounds(db_connection):
+    Session = sessionmaker(db_connection)
+    session = Session()
+
+    query = query_descendants_by_name("acetaminophen", vocabulary_ids=["RxNorm"])
+    results = session.execute(query).fetchall()
+    session.close()
+
+    assert len(results) > 1
+
+    names = [result[0].concept_name for result in results]
+    assert "Painaid BRF Oral Product" in names


### PR DESCRIPTION
## Pull Request Contents


| |
|-|
♻️ Refactor
✨ Feature


## Description

I've moved the query used in the OMOP_match class into a `omop_queries` script, and added other queries:

1) Fetches relationships for a concept
2) Fetches ancestors for a concept
3) Fetches descendants for a concept

Each of these will run for either a name or an id, optionally restricted to specific vocabulary_ids.

These are then used to define evaluation metrics - one for precision against a list of related concepts, one for precision against a list of ancestor concepts

## Related Issues or other material

- [X] This PR relates to one or more issues, detailed below

- Related Issue #78 
- Closes #78 


## ✅ Added/updated tests?

- [X] This PR contains relevant tests
  - Or doesn't need to per the below explanation

- [X] I've completed all **actions** and **tasks** detailed in the PR Template
