### PR TITLE
Deliverable/77/related or ancestor metrics

### DIFF
--- a/Lettuce/evaluation/metrics.py
+++ b/Lettuce/evaluation/metrics.py
@@ -162,7 +162,7 @@ class RelatedNameUncasedMatch(SingleResultMetric):
     def __init__(
         self,
         connection: Session,
-        vocabulary_ids: list[str],
+        vocabulary_ids: list[str] | None = None,
     ) -> None:
         self._description = "Related name: Is the output of a pipeline a related concept to the target concept?"
         self._connection = connection
@@ -192,7 +192,7 @@ class AncestorNameUncasedMatch(SingleResultMetric):
     def __init__(
         self,
         connection: Session,
-        vocabulary_ids: list[str],
+        vocabulary_ids: list[str] | None = None,
         min_separation_bound: int = 0,
         max_separation_bound: int | None = None,
     ) -> None:

--- a/Lettuce/evaluation/metrics.py
+++ b/Lettuce/evaluation/metrics.py
@@ -169,8 +169,9 @@ class RelatedNameUncasedMatch(SingleResultMetric):
         self._vocabulary_ids = vocabulary_ids
 
     def calculate(self, predicted, actual) -> float:
+        predicted = predicted.lower().strip()
         # If the correct concept is returned, I think a concept should relate to itself
-        if predicted.lower() == actual.lower():
+        if predicted == actual.lower().strip():
             return 1.0
         query = query_related_by_name(
             actual,
@@ -180,8 +181,11 @@ class RelatedNameUncasedMatch(SingleResultMetric):
         related_names = set(
             result[0].concept_name.lower() for result in related_concepts
         )
+        print(related_names)
+        print(predicted)
+        print(float(predicted in related_names))
 
-        return float(predicted.lower() in related_names)
+        return float(predicted in related_names)
 
     @property
     def description(self) -> str:

--- a/Lettuce/evaluation/pipelines.py
+++ b/Lettuce/evaluation/pipelines.py
@@ -26,7 +26,6 @@ class LLMPipeline(SingleResultPipeline):
         template_vars: list[str]
             The variables inserted into the prompt template when rendered
         """
-        self.llm = llm
         self.prompt_template = prompt_template
         self._model = llm
         self._template_vars = template_vars
@@ -49,7 +48,7 @@ class LLMPipeline(SingleResultPipeline):
             {(v, i) for v, i in zip(self._template_vars, input)}
         )
         reply = self._model.create_completion(prompt=prompt)["choices"][0]["text"]
-        print(f"{self.llm.value} replied {reply} for {input}")
+        print(f"Replied {reply} for {input}")
         return reply
 
     def drop(self):
@@ -90,4 +89,5 @@ class RAGPipeline(SingleResultPipeline):
             dict(zip(self._template_vars, [*input, search_results["documents"]]))
         )
         reply = self._llmodel.create_completion(prompt=prompt)["choices"][0]["text"]
+        print(f"Replied {reply} for {input}")
         return reply

--- a/Lettuce/evaluation/pipelines.py
+++ b/Lettuce/evaluation/pipelines.py
@@ -1,11 +1,8 @@
 from sentence_transformers import SentenceTransformer
 from torch.functional import Tensor
 from evaluation.evaltypes import SingleResultPipeline
-from options.pipeline_options import LLMModel
-from components.models import local_models
 from jinja2 import Template
 from llama_cpp import Llama
-from huggingface_hub import hf_hub_download
 from haystack_integrations.components.retrievers.qdrant import QdrantEmbeddingRetriever
 
 
@@ -15,7 +12,7 @@ class LLMPipeline(SingleResultPipeline):
     """
 
     def __init__(
-        self, llm: LLMModel, prompt_template: Template, template_vars: list[str]
+        self, llm: Llama, prompt_template: Template, template_vars: list[str]
     ) -> None:
         """
         Initialises the LLMPipeline class
@@ -31,13 +28,7 @@ class LLMPipeline(SingleResultPipeline):
         """
         self.llm = llm
         self.prompt_template = prompt_template
-        self._model = Llama(
-            hf_hub_download(**local_models[self.llm.value]),
-            n_ctx=0,
-            n_batch=512,
-            model_kwargs={"n_gpu_layers": -1, "verbose": True},
-            generation_kwargs={"max_tokens": 128, "temperature": 0},
-        )
+        self._model = llm
         self._template_vars = template_vars
 
     def run(self, input: list[str]) -> str:
@@ -77,7 +68,7 @@ class EmbeddingsPipeline(SingleResultPipeline):
 class RAGPipeline(SingleResultPipeline):
     def __init__(
         self,
-        llm: LLMModel,
+        llm: Llama,
         prompt_template: Template,
         template_vars: list[str],
         embedding_model: SentenceTransformer,
@@ -86,13 +77,7 @@ class RAGPipeline(SingleResultPipeline):
     ) -> None:
         self.llm = llm
         self.prompt_template = prompt_template
-        self._llmodel = Llama(
-            hf_hub_download(**local_models[self.llm.value]),
-            n_ctx=0,
-            n_batch=512,
-            model_kwargs={"n_gpu_layers": -1, "verbose": True},
-            generation_kwargs={"max_tokens": 128, "temperature": 0},
-        )
+        self._llmodel = llm
         self._embedding_model = embedding_model
         self._template_vars = template_vars
         self._retriever = retriever

--- a/Lettuce/omop/omop_queries.py
+++ b/Lettuce/omop/omop_queries.py
@@ -157,7 +157,9 @@ def query_descendants_by_name(
 def query_ancestors_by_id() -> Select: ...
 
 
-def query_related_by_name(query_concept: str, vocabulary_ids: list[str]) -> Select:
+def query_related_by_name(
+    query_concept: str, vocabulary_ids: list[str] | None
+) -> Select:
     matching_names = query_ids_matching_name(query_concept, vocabulary_ids).cte()
     return (
         select(Concept)

--- a/Lettuce/tests/test_evals.py
+++ b/Lettuce/tests/test_evals.py
@@ -11,6 +11,7 @@ from evaluation.evaltypes import (
     EvaluationFramework,
 )
 from evaluation.metrics import (
+    AncestorNameUncasedMatch,
     ExactMatch,
     FuzzyMatchRatio,
     PrecisionMetric,
@@ -18,6 +19,7 @@ from evaluation.metrics import (
     FScoreMetric,
     AncestorNamePrecision,
     RelatedNamePrecision,
+    RelatedNameUncasedMatch,
 )
 from evaluation.pipelines import LLMPipeline
 from evaluation.eval_data_loaders import SingleInputSimpleCSV
@@ -174,6 +176,32 @@ class TestDatabaseMetrics:
         assert full_match == 1.0
         assert half_match == 0.5
         assert no_match == 0
+
+    def test_related_name_uncased_match(self, db_connection):
+        metric = RelatedNameUncasedMatch(db_connection, ["RxNorm"])
+
+        concept_match = metric.calculate("acetaminophen", "Acetaminophen")
+        concept_related = metric.calculate(
+            "acetaminophen / dextromethorphan Oral Powder Product", "Acetaminophen"
+        )
+        concept_not_related = metric.calculate("Oxford Circus", "Acetaminophen")
+
+        assert concept_match == 1.0
+        assert concept_related == 1.0
+        assert concept_not_related == 0
+
+    def test_ancestor_name_uncased_match(self, db_connection):
+        metric = AncestorNameUncasedMatch(db_connection, ["RxNorm"])
+
+        concept_match = metric.calculate("acetaminophen", "Acetaminophen")
+        concept_related = metric.calculate(
+            "codeine and other non-opioid analgesics; systemic", "Acetaminophen"
+        )
+        concept_not_related = metric.calculate("Oxford Circus", "Acetaminophen")
+
+        assert concept_match == 1.0
+        assert concept_related == 1.0
+        assert concept_not_related == 0
 
 
 # LLM pipeline tests


### PR DESCRIPTION
## Pull Request Contents

| |
|-|
♻️ Refactor
✨ Feature
🦋 Bug Fix
⚡️ Optimization

## Description

Overall, I've added the related and ancestor versions of the uncased match metric. The biggest structural change I made is to the LLMPipeline class. Instead of taking an LLMModel description of the model, it takes the model itself. This is important because it means that we only need to load each model once. This is important, for example, if you want to test the same model with a bunch of different prompts. This will break previous experiment scripts, but as they've only been me playing around, it doesn't matter much.

## Related Issues or other material

- [X] This PR relates to one or more issues, detailed below

- Related Issue #77 
- Closes #77 


## ✅ Added/updated tests?

- [X] This PR contains relevant tests
  - Or doesn't need to per the below explanation

Also usable in standalone scripts


- [X] I've completed all **actions** and **tasks** detailed in the PR Template
