### PR TITLE
Fix pipeline for dev image

### DIFF
--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: SebRollen/toml-action@v1.2.0
         id: read_version
         with:
-          file: pyproject.toml
+          file: "lettuce/pyproject.toml"
           field: project.version
 
       - name: Docker Metadata action

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -74,7 +74,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: "./lettuce"
-          file: Dockerfile
+          file: "lettuce/Dockerfile"
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -74,7 +74,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
-          file: Dockerfile
+          file: "lettuce/Dockerfile"
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      #- name: Set up QEMU
+      #  uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
@@ -76,7 +76,7 @@ jobs:
           context: "./lettuce"
           file: "lettuce/Dockerfile"
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 # ,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v5.3.0
         with:
-          context: .
-          file: "lettuce/Dockerfile"
+          context: "./lettuce"
+          file: Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -5,7 +5,7 @@ name: Publish a Dev Release
 
 on:
   push:
-    branches: [fix-pipeline-for-dev-image]
+    branches: [main]
 
 env:
   image-name: lettuce

--- a/.github/workflows/release.dev.yml
+++ b/.github/workflows/release.dev.yml
@@ -5,7 +5,7 @@ name: Publish a Dev Release
 
 on:
   push:
-    branches: [main]
+    branches: [fix-pipeline-for-dev-image]
 
 env:
   image-name: lettuce


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
Incorrect relative paths for the docker build context, `Dockerfile`, and `pyproject.toml` were causing the dev docker image release pipeline to fail. I have specified the correct paths in the `release-dev.yml` to rectify this. 

## Related Issues or other material
Related #124 
Closes #124 

## ✅ Added/updated tests?
- [] Tested manually by temporarily changing the pipeline trigger to `fix-pipeline-for-dev-image` branch and verify that the image was successfully published to the GitHub image registry.  
