### PR TITLE
Deliverable/image with model weights

### DIFF
--- a/.github/workflows/release.dev-base.yml
+++ b/.github/workflows/release.dev-base.yml
@@ -1,0 +1,82 @@
+# Automates the process of building and publishing a Docker container image whenever changes are pushed to the main branch.
+# The resulting image is tagged as a development release and published to GitHub Container Registry (ghcr.io).
+
+name: Publish a Dev Release
+
+on:
+  push:
+    branches: [main]
+
+env:
+  image-name: lettuce
+  repo-owner: ${{ github.repository_owner }}
+  registry: ghcr.io
+
+jobs:
+  publish-lettuce-base:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      #- name: Set up QEMU
+      #  uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Docker Login
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: SebRollen/toml-action@v1.2.0
+        id: read_version
+        with:
+          file: "lettuce/pyproject.toml"
+          field: project.version
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.image-name }}
+          # Tag notes:
+          # - RFC3339 (standardised format for timestamps) is not suitable for docker tags, so we squash the date
+          # - We tag both the short (7-char prefixed) and full sha commit hashes; both are useful
+          # - `edge` represents latest main branch commit (potentially unstable)
+          tags: |
+            type=sha
+            ${{ github.sha }}
+            type=raw,value={{date 'YYYYMMDDHHmmss[Z]'}}
+            edge
+          # Label notes:
+          # - Static labels are applied in the Dockerfile
+          # - Date format in `org.opencontainers.image.created` must be RFC3339
+          # - version should be considered a semver candidate only, unless revision aligns with a git tag
+          labels: |
+            org.opencontainers.image.revision={{sha}}
+            org.opencontainers.image.version=${{ steps.read_version.outputs.value }}
+            org.opencontainers.image.created={{date 'YYYY-MM-DD HH:mm:ss[Z]'}}
+          # TODO: More Annotations may be desirable instead of labels for some metadata,
+          # since we produce multiarch images
+          annotations: |
+            org.opencontainers.image.description=lettuce
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: "./lettuce"
+          file: "lettuce/Dockerfile"
+          push: true
+          platforms: linux/amd64 # ,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/release.dev-base.yml
+++ b/.github/workflows/release.dev-base.yml
@@ -53,10 +53,10 @@ jobs:
           # - We tag both the short (7-char prefixed) and full sha commit hashes; both are useful
           # - `edge` represents latest main branch commit (potentially unstable)
           tags: |
-            type=sha
-            ${{ github.sha }}
-            type=raw,value={{date 'YYYYMMDDHHmmss[Z]'}}
-            edge
+            type=sha,prefix=dev-base- 
+            dev-base-${{ github.sha }}
+            type=raw,value=dev-base-{{date 'YYYYMMDDHHmmss[Z]'}}
+            dev-base-edge
           # Label notes:
           # - Static labels are applied in the Dockerfile
           # - Date format in `org.opencontainers.image.created` must be RFC3339

--- a/.github/workflows/release.dev-weights.yml
+++ b/.github/workflows/release.dev-weights.yml
@@ -1,3 +1,7 @@
+# Builds and publishes a Docker container image with pre-loaded LLaMA-3.1-8B weights for the Lettuce project.
+# This workflow is manually triggered, tags the image as a development release with the 'dev-weights-llama-3.1-8B' prefix,
+# and pushes it to GitHub Container Registry (ghcr.io).
+
 name: Build and publish pre-loaded weights image
 
 on:
@@ -53,7 +57,7 @@ jobs:
           images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.image-name }}
           # Tag notes:
           # - RFC3339 (standardised format for timestamps) is not suitable for docker tags, so we squash the date
-          # - We tag both the short (7-char prefixed) and full sha commit hashes; both are useful
+          # - We only tag the short (7-char prefixed) commit hashes as this is a dev image 
           # - `edge` represents latest main branch commit (potentially unstable)
           tags: |
             type=sha,prefix=dev-weights-${{ env.model-name }}-

--- a/.github/workflows/release.dev-weights.yml
+++ b/.github/workflows/release.dev-weights.yml
@@ -1,19 +1,22 @@
-# Automates the process of building and publishing a Docker container image whenever changes are pushed to the main branch.
-# The resulting image is tagged as a development release and published to GitHub Container Registry (ghcr.io).
-
-name: Publish a Dev Release
+name: Build and publish pre-loaded weights image
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch: 
+    inputs: 
+      branch: 
+        description: "Branch to build from"
+        required: true 
+        default: "main"
 
 env:
   image-name: lettuce
   repo-owner: ${{ github.repository_owner }}
   registry: ghcr.io
+  model-name: llama-3.1-8B
+
 
 jobs:
-  publish-lettuce:
+  publish-lettuce-weights:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -53,10 +56,9 @@ jobs:
           # - We tag both the short (7-char prefixed) and full sha commit hashes; both are useful
           # - `edge` represents latest main branch commit (potentially unstable)
           tags: |
-            type=sha
-            ${{ github.sha }}
-            type=raw,value={{date 'YYYYMMDDHHmmss[Z]'}}
-            edge
+            type=sha,prefix=dev-weights-${{ env.model-name }}-
+            type=raw,value=dev-weights-${{ env.model-name }}-{{date 'YYYYMMDDHHmmss[Z]'}}
+            dev-weights-${{ env.model-name }}-edge
           # Label notes:
           # - Static labels are applied in the Dockerfile
           # - Date format in `org.opencontainers.image.created` must be RFC3339
@@ -74,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: "./lettuce"
-          file: "lettuce/Dockerfile"
+          file: "lettuce/Dockerfile.model"
           push: true
           platforms: linux/amd64 # ,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ The response will be provided in the format
 
 The response will be streamed asynchronously so the llm_output will arrive before any omop_output
 
+## Published Images
+Development Docker images for the Lettuce project are available on GitHub Container Registry (GHCR):
+
+- **Registry**: `ghcr.io/health-informatics-uon/lettuce`
+- **Images**:
+  - **Weights Image**: Includes pre-loaded LLaMA-3.1-8B weights.
+    - **Tags**:
+      - `dev-weights-llama-3.1-8B-sha-<hash>` (e.g., `dev-weights-llama-3.1-8B-sha-a1b2c3d`): Build from a specific commit.
+      - `dev-weights-llama-3.1-8B-edge`: Latest development image with weights.
+    - **Pull Command**: 
+      ```bash
+      docker pull ghcr.io/health-informatics-uon/lettuce:dev-weights-llama-3.1-8B-edge
+  - **Base Image**: Lightweight image without weights, for custom setups.
+    - **Tags**: 
+      - `dev-base-sha-<hash>` (e.g., `dev-base-sha-a1b2c3d`): Build from a specific commit.
+      - `dev-base-edge`: Latest development image with weights.
+    - **Pull Command**: 
+      ```bash
+      docker pull ghcr.io/health-informatics-uon/lettuce:dev-base-edge
+      ```
+
 ## Contact
 
 If there are any bugs, please [email us](mailto:james.mitchell-white1@nottingham.ac.uk)

--- a/lettuce/Dockerfile
+++ b/lettuce/Dockerfile
@@ -15,6 +15,14 @@ ENV PATH="/src/.venv/bin:$PATH"
 WORKDIR src
 COPY --from=builder /src/.venv /src/.venv
 
+LABEL org.opencontainers.image.title=Lettuce
+LABEL org.opencontainers.image.description=lettuce-dev-base 
+LABEL org.opencontainers.image.vendor=University\ of\ Nottingham
+LABEL org.opencontainers.image.url=https://github.com/Health-Informatics-UoN/lettuce/pkgs/container/lettuce
+LABEL org.opencontainers.image.documentation=https://health-informatics-uon.github.io/lettuce/
+LABEL org.opencontainers.image.source=https://github.com/Health-Informatics-UoN/lettuce
+LABEL org.opencontainers.image.licenses=MIT
+
 COPY . .
 EXPOSE 8000
 

--- a/lettuce/Dockerfile.model
+++ b/lettuce/Dockerfile.model
@@ -23,6 +23,14 @@ RUN HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \
     --local-dir models
 ENV LOCAL_LLM="models/Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf"
 
+LABEL org.opencontainers.image.title=Lettuce
+LABEL org.opencontainers.image.description=lettuce-dev-weights
+LABEL org.opencontainers.image.vendor=University\ of\ Nottingham
+LABEL org.opencontainers.image.url=https://github.com/Health-Informatics-UoN/lettuce/pkgs/container/lettuce
+LABEL org.opencontainers.image.documentation=https://health-informatics-uon.github.io/lettuce/
+LABEL org.opencontainers.image.source=https://github.com/Health-Informatics-UoN/lettuce
+LABEL org.opencontainers.image.licenses=MIT
+
 COPY . .
 EXPOSE 8000
 

--- a/lettuce/Dockerfile.model
+++ b/lettuce/Dockerfile.model
@@ -8,19 +8,20 @@ ENV UV_CACHE_DIR=/tmp/uv_cache \
 
 WORKDIR /src
 COPY pyproject.toml ./
-RUN uv sync 
+RUN uv sync
+
+RUN pip install "huggingface_hub[hf_transfer]" "hf_transfer"
+RUN mkdir -p models
+RUN HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \
+    "MaziyarPanahi/Meta-Llama-3.1-8B-Instruct-GGUF" \
+    "Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf" \
+    --local-dir models
 
 FROM python:3.12-slim-bookworm
-ENV PATH="/src/.venv/bin:$PATH"
-WORKDIR src
+WORKDIR /src
 COPY --from=builder /src/.venv /src/.venv
-
-RUN mkdir -p models  
-RUN pip install --no-cache-dir "huggingface_hub[hf_transfer]"
-RUN HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \ 
-    "MaziyarPanahi/Meta-Llama-3.1-8B-Instruct-GGUF" \
-    "Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf" \ 
-    --local-dir models
+COPY --from=builder /src/models /src/models
+ENV PATH="/src/.venv/bin:$PATH"
 ENV LOCAL_LLM="models/Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf"
 
 LABEL org.opencontainers.image.title=Lettuce

--- a/lettuce/Dockerfile.model
+++ b/lettuce/Dockerfile.model
@@ -15,6 +15,14 @@ ENV PATH="/src/.venv/bin:$PATH"
 WORKDIR src
 COPY --from=builder /src/.venv /src/.venv
 
+RUN mkdir -p models  
+RUN pipx install "huggingface_hub[hf_transfer]"
+RUN HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \ 
+    "MaziyarPanahi/Meta-Llama-3.1-8B-Instruct-GGUF" \
+    "Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf" \ 
+    --local-dir models
+ENV LOCAL_LLM="model_weights/Llama-3.1-8B"
+
 COPY . .
 EXPOSE 8000
 

--- a/lettuce/Dockerfile.model
+++ b/lettuce/Dockerfile.model
@@ -16,12 +16,12 @@ WORKDIR src
 COPY --from=builder /src/.venv /src/.venv
 
 RUN mkdir -p models  
-RUN pipx install "huggingface_hub[hf_transfer]"
+RUN pip install --no-cache-dir "huggingface_hub[hf_transfer]"
 RUN HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download \ 
     "MaziyarPanahi/Meta-Llama-3.1-8B-Instruct-GGUF" \
     "Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf" \ 
     --local-dir models
-ENV LOCAL_LLM="model_weights/Llama-3.1-8B"
+ENV LOCAL_LLM="models/Meta-Llama-3.1-8B-Instruct.Q4_K_M.gguf"
 
 COPY . .
 EXPOSE 8000

--- a/lettuce/omop/omop_models.py
+++ b/lettuce/omop/omop_models.py
@@ -1,15 +1,16 @@
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy import Column, Date, Integer, String
 from pgvector.sqlalchemy import Vector
+from dotenv import load_dotenv
 
 from os import environ
 
+load_dotenv()
 DB_SCHEMA = environ["DB_SCHEMA"]
 DB_VECTABLE = environ["DB_VECTABLE"]
 DB_VECSIZE = int(environ["DB_VECSIZE"])
 
 Base = declarative_base()
-
 
 class Concept(Base):
     """

--- a/lettuce/omop/omop_models.py
+++ b/lettuce/omop/omop_models.py
@@ -1,11 +1,9 @@
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy import Column, Date, Integer, String
 from pgvector.sqlalchemy import Vector
-from dotenv import load_dotenv
 
 from os import environ
 
-load_dotenv()
 DB_SCHEMA = environ["DB_SCHEMA"]
 DB_VECTABLE = environ["DB_VECTABLE"]
 DB_VECSIZE = int(environ["DB_VECSIZE"])


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
An dev image with model weights is now published to the GitHub image registry. I have achieved this through: 
- I have added a new dockerfile - `Dockerfile.model` which downloads and bakes in the models weights into the image. 
- For now, only the weights of the default model `llama-3.1-8B` are included.  
- Added a new GitHub actions workflow `release.dev-weights.yml` which publishes this image to the image registry via a manual trigger. 
- The image is tagged with the prefix `dev-weights-llama-3.1-8B`
- Added labels to both the base and weights images. 

## Related Issues or other material
Related #120
Closes #120 

## ✅ Added/updated tests?
- Manual testing of workflow and publishing to the github image registry. 
- Manually tested the docker image build locally and verified that the build is successful and model weights are present within the image. 
