### PR TITLE
Deliverable/add e2e tests for cli

### DIFF
--- a/lettuce/components/models.py
+++ b/lettuce/components/models.py
@@ -122,12 +122,12 @@ def get_local_weights(
     llm = LlamaCppGenerator(
         model=path_to_weights, 
         model_kwargs={
-            "n_ctx": 512,
+            "n_ctx": 2048,
             "n_batch": 32,
             "n_gpu_layers": device,
             "verbose": True
         }, 
-        generation_kwargs={"max_tokens": 128, "temperature": temperature}
+        generation_kwargs={"max_tokens": 64, "temperature": temperature}
     )
     logger.info(f"Succesfully loaded LlamaCppGenerator from {path_to_weights}")
     logger.info(f"LLM Loaded: n_ctx={llm.config.get('n_ctx')}, n_batch={llm.config.get('n_batch')}")
@@ -139,9 +139,9 @@ def download_model_from_huggingface(
     temperature: float, 
     logger: logging.Logger, 
     fallback_model: str = "llama-3.1-8b",
-    n_ctx: int = 512,
+    n_ctx: int = 2048,
     n_batch: int = 32,
-    max_tokens: int = 128 
+    max_tokens: int = 64
 ): 
     logger.info(f"Loading local model: {model_name}")
     device = -1 if torch.cuda.is_available() else 0

--- a/lettuce/tests/e2e/test_cli.py
+++ b/lettuce/tests/e2e/test_cli.py
@@ -1,0 +1,92 @@
+from pathlib import Path 
+import ast  
+import subprocess 
+import pytest 
+
+
+def run_lettuce_cli_command(cli_args: list[str]): 
+    cmd = ["uv", "run", "--env-file", ".env", "lettuce-cli"]
+    cmd.extend(cli_args)   
+    return subprocess.run(
+        cmd, 
+        capture_output=True, 
+        text=True 
+    )
+
+
+def parse_output(output_str: str): 
+    def find_balanced_brackets(s, start):
+        open_count = 0
+        for i in range(start, len(s)):
+            if s[i] == '[':
+                open_count += 1
+            elif s[i] == ']':
+                open_count -= 1
+                if open_count == 0:
+                    return i + 1  
+        return -1  
+    output_str = output_str.strip()
+    list_start = output_str.find('[{')
+    list_end = find_balanced_brackets(output_str, list_start)
+    if list_start >= 0 and list_end > list_start:
+        json_str = output_str[list_start:list_end]
+        return ast.literal_eval(json_str)
+    raise ValueError(f"Could not find JSON list in output: {output_str}")
+
+
+def test_basic_search():  
+    result = run_lettuce_cli_command([
+        "--no-vector_search", 
+        "--no-use_llm", 
+        "--vocabulary_id", 
+        "RxNorm", 
+        "--informal_names", 
+        "acetaminophen"
+    ])
+    output = parse_output(result.stdout)
+    assert result.returncode == 0 
+    assert len(output) > 0 
+    assert any(match["concept_name"] == "acetaminophen" for match in output)
+    assert all(match["vocabulary_id"] == "RxNorm" for match in output)
+
+
+def test_vector_search(): 
+    result = run_lettuce_cli_command([
+        "--vector_search", 
+        "--no-use_llm", 
+        "--vocabulary_id", 
+        "RxNorm", 
+        "--informal_names", 
+        "acetaminophen"
+    ])
+    output = parse_output(result.stdout)
+    omop_matches = output[0]["OMOP matches"]["CONCEPT"]
+    vector_search_results = output[0]["Vector Search Results"]
+    assert result.returncode == 0 
+    assert len(output) > 0 
+    assert len(omop_matches) > 0 
+    assert any(match["concept_name"] == "acetaminophen" for match in omop_matches)
+    assert all(match["vocabulary_id"] == "RxNorm" for match in omop_matches)
+    assert len(vector_search_results) > 0 
+    assert any(match["concept"] == "Acetaminophen" for match in vector_search_results)
+
+
+def test_llm_pipeline(): 
+    result = run_lettuce_cli_command([
+        "--vector_search", 
+        "--use_llm", 
+        "--vocabulary_id", 
+        "RxNorm", 
+        "--informal_names", 
+        "acetaminophen"
+    ])
+    output = parse_output(result.stdout)
+    breakpoint()
+
+
+def test_combined_vector_and_llm(): 
+    pass 
+
+
+if __name__ == "__main__": 
+    pass 

--- a/lettuce/tests/e2e/test_cli.py
+++ b/lettuce/tests/e2e/test_cli.py
@@ -1,7 +1,15 @@
-from pathlib import Path 
 import ast  
 import subprocess 
+import time 
 import pytest 
+
+
+@pytest.fixture(autouse=True, scope="session")
+def time_e2e_session():
+    start = time.time()
+    yield
+    end = time.time()
+    print(f"\nTotal E2E test duration: {end - start:.2f} seconds")
 
 
 def run_lettuce_cli_command(cli_args: list[str]): 
@@ -44,10 +52,11 @@ def test_basic_search():
         "acetaminophen"
     ])
     output = parse_output(result.stdout)
+    omop_matches = output[0]["OMOP matches"]["CONCEPT"]
     assert result.returncode == 0 
     assert len(output) > 0 
-    assert any(match["concept_name"] == "acetaminophen" for match in output)
-    assert all(match["vocabulary_id"] == "RxNorm" for match in output)
+    assert any(match["concept_name"] == "acetaminophen" for match in omop_matches)
+    assert all(match["vocabulary_id"] == "RxNorm" for match in omop_matches)
 
 
 def test_vector_search(): 
@@ -73,20 +82,37 @@ def test_vector_search():
 
 def test_llm_pipeline(): 
     result = run_lettuce_cli_command([
-        "--vector_search", 
+        "--no-vector_search", 
         "--use_llm", 
         "--vocabulary_id", 
         "RxNorm", 
+        "--model_name", 
+        "tinyllama-1.1b-chat", 
         "--informal_names", 
         "acetaminophen"
     ])
     output = parse_output(result.stdout)
-    breakpoint()
+    assert len(output) > 0
+    assert output[0]["llm_answer"] == "Acetaminophen"
 
 
 def test_combined_vector_and_llm(): 
-    pass 
-
-
-if __name__ == "__main__": 
-    pass 
+    result = run_lettuce_cli_command([
+        "--vector_search", 
+        "--use_llm", 
+        "--vocabulary_id", 
+        "RxNorm", 
+        "--model_name", 
+        "tinyllama-1.1b-chat", 
+        "--informal_names", 
+        "acetaminophen"
+    ])
+    output = parse_output(result.stdout)
+    omop_matches = output[0]["OMOP matches"]["CONCEPT"]
+    vector_search_results = output[0]["Vector Search Results"]
+    assert result.returncode == 0 
+    assert len(output) > 0 
+    assert len(omop_matches) > 0 
+    assert output[0]["llm_answer"] == "Acetaminophen"
+    assert len(vector_search_results) > 0 
+    assert any(match["content"] == "Acetaminophen" for match in vector_search_results)


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description
The `lettuce-cli` has some unit style tests in `test/unit` but these make use of extensive mocking and don't test real life interactions between different components of the pipeline. It would be good to have some rudimentary end-to-end tests for the CLI tool. 

## Related Issues or other material
Related #
Closes #

## ✅ Added/updated tests?
- [] Yes this PR updated the `tests` folder to now include `tests/e2e/test_cli.py`

