### PR TITLE
Deliverable/get ai search endpoints

### DIFF
--- a/lettuce/api_models/responses.py
+++ b/lettuce/api_models/responses.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 class Suggestion(BaseModel):
@@ -16,6 +16,7 @@ class SuggestionsMetaData(BaseModel):
     assistant: str = "Lettuce"
     version: str = "0.1.0"
     pipeline: Optional[str] = None
+    info: Optional[Dict[str, Any]] = None
 
 class ConceptSuggestionResponse(BaseModel):
     recommendations: List[Suggestion]

--- a/lettuce/components/models.py
+++ b/lettuce/components/models.py
@@ -117,12 +117,13 @@ def get_local_weights(
    
     logger.info(f"Loading local model weights from {path_to_weights}")
     device = -1 if torch.cuda.is_available() else 0 
+    logger.info(f"Using {device} GPU layers")
 
     # Load the model using llama 
     llm = LlamaCppGenerator(
         model=path_to_weights, 
         model_kwargs={
-            "n_ctx": 512,
+            "n_ctx": 1024,
             "n_batch": 32,
             "n_gpu_layers": device,
             "verbose": True
@@ -139,12 +140,13 @@ def download_model_from_huggingface(
     temperature: float, 
     logger: logging.Logger, 
     fallback_model: str = "llama-3.1-8b",
-    n_ctx: int = 512,
+    n_ctx: int = 1024,
     n_batch: int = 32,
     max_tokens: int = 128 
 ): 
     logger.info(f"Loading local model: {model_name}")
     device = -1 if torch.cuda.is_available() else 0
+    logger.info(f"Using {device} GPU layers")
 
     try: 
         model_config = local_models[model_name]

--- a/lettuce/components/models.py
+++ b/lettuce/components/models.py
@@ -116,7 +116,7 @@ def get_local_weights(
         raise FileNotFoundError(f"Model weights file not found at {path_to_weights}")
    
     logger.info(f"Loading local model weights from {path_to_weights}")
-    device = -1 if torch.cuda.is_available() else 0 
+    device = -1 if (torch.cuda.is_available() or torch.backends.mps.is_available()) else 0
     logger.info(f"Using {device} GPU layers")
 
     # Load the model using llama 
@@ -145,7 +145,7 @@ def download_model_from_huggingface(
     max_tokens: int = 128 
 ): 
     logger.info(f"Loading local model: {model_name}")
-    device = -1 if torch.cuda.is_available() else 0
+    device = -1 if (torch.cuda.is_available() or torch.backends.mps.is_available()) else 0
     logger.info(f"Using {device} GPU layers")
 
     try: 

--- a/lettuce/omop/omop_queries.py
+++ b/lettuce/omop/omop_queries.py
@@ -138,10 +138,24 @@ def get_all_vocabs() -> Select:
     return select(Concept.vocabulary_id.distinct())
 
 
-def query_ids_matching_name(query_concept, vocabulary_ids: list[str] | None) -> Select:
-    base_query = select(
-        Concept.concept_id,
-    ).where(func.lower(Concept.concept_name) == query_concept.lower())
+def query_ids_matching_name(
+        query_concept,
+        vocabulary_ids: list[str] | None,
+        full_concept: bool = False
+        ) -> Select:
+    if full_concept:
+        base_query = select(
+            Concept.concept_name,
+            Concept.concept_id,
+            Concept.domain_id,
+            Concept.vocabulary_id,
+            Concept.concept_class_id,
+            Concept.standard_concept,
+            Concept.invalid_reason,
+            )
+    else:
+        base_query = select(Concept.concept_id)
+    base_query = base_query.where(func.lower(Concept.concept_name) == query_concept.lower())
     if vocabulary_ids:
         return base_query.where(Concept.vocabulary_id.in_(vocabulary_ids))
     else:

--- a/lettuce/routers/search_routes.py
+++ b/lettuce/routers/search_routes.py
@@ -2,8 +2,11 @@ from typing import Annotated, List
 from fastapi import APIRouter, Query
 
 from api_models.responses import ConceptSuggestionResponse, Suggestion, SuggestionsMetaData
+from components.pipeline import LLMPipeline
 from omop.db_manager import get_session
-from omop.omop_queries import count_concepts, ts_rank_query
+from omop.omop_queries import count_concepts, query_ids_matching_name, ts_rank_query
+from options.pipeline_options import LLMModel
+from utils.logging_utils import logger
 
 router = APIRouter()
 
@@ -53,4 +56,86 @@ async def text_search(
                 ],
             metadata=metadata
             )
+    return response
+
+@router.get("/ai-search/{search_term}")
+async def ai_search(
+        search_term: str,
+        vocabulary_id: Annotated[List[str] | None, Query()]=None,
+        domain_id: Annotated[List[str] | None, Query()]=None,
+        standard_concept: bool=False,
+        valid_concept: bool=False,
+        top_k: Annotated[int, Query(title="The number of responses to fetch", ge=1)]=5,
+        ) -> ConceptSuggestionResponse:
+    assistant = LLMPipeline(
+            llm_model=LLMModel.LLAMA_3_1_8B,
+            temperature=0,
+            logger=logger,
+            embed_vocab=vocabulary_id,
+            standard_concept=standard_concept,
+            ).get_rag_assistant()
+    answer = assistant.run({"prompt": {"informal_name": search_term}, "query_embedder": {"text": search_term}})
+    reply = answer["llm"]["replies"][0].strip()
+    meta = answer["llm"]["meta"]
+    logger.info(f"Reply: {reply}")
+    logger.info(f"Meta: {meta}")
+    query = query_ids_matching_name(
+            query_concept=reply,
+            vocabulary_ids=vocabulary_id,
+            full_concept=True
+            )
+    metadata = SuggestionsMetaData(
+            pipeline="LLM RAG pipeline",
+            info={
+                "LLM": "Llama 3.1 8b (quantised to 4-bit)",
+                "LLM reply": reply,
+                }
+            )
+    with get_session() as session:
+        results = session.execute(query).fetchall()
+    if len(results) == 0:
+        ts_query = ts_rank_query(
+                search_term=reply,
+                vocabulary_id=vocabulary_id,
+                domain_id=domain_id,
+                standard_concept=standard_concept,
+                valid_concept=valid_concept,
+                top_k=top_k,
+                )
+        with get_session() as session:
+            results = session.execute(ts_query).fetchall()
+        response = ConceptSuggestionResponse(
+            recommendations=[
+                Suggestion(
+                    concept_name=r.concept_name,
+                    concept_id=r.concept_id,
+                    domain_id=r.domain_id,
+                    vocabulary_id=r.vocabulary_id,
+                    concept_class_id=r.concept_class_id,
+                    standard_concept=r.standard_concept,
+                    invalid_reason=r.invalid_reason,
+                    ranks={"text_search": i+1},
+                    scores={"text_search": r.ts_rank},
+                    ) for i, r in enumerate(results)
+                ],
+            metadata=metadata
+            )
+    else:
+        response = ConceptSuggestionResponse(
+            recommendations=[
+                Suggestion(
+                    concept_name=r.concept_name,
+                    concept_id=r.concept_id,
+                    domain_id=r.domain_id,
+                    vocabulary_id=r.vocabulary_id,
+                    concept_class_id=r.concept_class_id,
+                    standard_concept=r.standard_concept,
+                    invalid_reason=r.invalid_reason,
+                    ranks={},
+                    scores={}
+                    ) for r in results
+                ],
+            metadata=metadata
+            )
+    
     return response

--- a/lettuce/tests/unit/test_models.py
+++ b/lettuce/tests/unit/test_models.py
@@ -47,7 +47,7 @@ def test_local_weights_success(mock_cuda, mock_llama, mock_isfile, mock_file_exi
     mock_isfile.assert_called_once_with(mock_file_exists)
     mock_llama.assert_called_once_with(
         model=mock_file_exists, 
-        model_kwargs={'n_ctx': 512, 'n_batch': 32, 'n_gpu_layers': -1, 'verbose': True},
+        model_kwargs={'n_ctx': 1024, 'n_batch': 32, 'n_gpu_layers': -1, 'verbose': True},
         generation_kwargs={'max_tokens': 128, 'temperature': 0.7}
     )
     mock_cuda.assert_called_once()


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature
🦋 Bug Fix
⚡️ Optimization

## PR Description
I've added an ai-search endpoint to the API. It follows the format of the text-search API, so you can just substitute `ai-search` for `text-search` on a URL to get the ai search result instead.

The pipeline is this:
- vector search results retrieved
- vector search added to the prompt
- LLM has a guess
- A SQL query looks for matching concept names in the vocabularies you want
- If no exact match is found, text-search is used as a fallback, using the LLM suggestion

I've made minor changes to other code:
- For the response endpoint, it might be useful to inform users of the LLM suggestion, so I added an optional "info" field to the response object
- The Llama instantiation would use GPU if cuda was available, but macs use the mps device, so the check didn't catch that and the GPU wouldn't be used on apple silicon
- Context window increased. Sometimes RAG pipelines use a little more than 512 because concept names are loooooooong

## Related Issues or other material
Related #144 
Closes #144 

## [optional] What gif best describes this PR or how it makes you feel?
![agent smith](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWNicGljdnB6eDUwa2d3dTB5cXFjd25idXB3bHY3MDZqeWgwcHl3bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nbpvCPsFLItHO/giphy.gif)
