### PR TITLE
Added API key authentication for lettuce API

### DIFF
--- a/lettuce/api.py
+++ b/lettuce/api.py
@@ -1,9 +1,12 @@
 import os 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Depends, HTTPException, status  
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials 
 from routers import pipeline_routes, search_routes
 
+
+load_dotenv()
 
 security = HTTPBearer()
 

--- a/lettuce/api.py
+++ b/lettuce/api.py
@@ -1,6 +1,27 @@
-from fastapi import FastAPI
+import os 
+from fastapi import FastAPI, Depends, HTTPException, status  
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials 
 from routers import pipeline_routes, search_routes
+
+
+security = HTTPBearer()
+
+def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    api_key = os.getenv("AUTH_API_KEY")
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Server configuration error: API_KEY not set"
+        )
+    valid_api_keys = {api_key}
+    if credentials.credentials not in valid_api_keys:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key"
+        )
+    return credentials.credentials
+
 
 app = FastAPI(
     title="OMOP concept Assistant",
@@ -23,12 +44,14 @@ app.add_middleware(
 app.include_router(
     router=pipeline_routes.router,
     prefix="/pipeline",
+    dependencies=[Depends(verify_api_key)]  
 )
 
 app.include_router(
-        router=search_routes.router,
-        prefix="/search",
-        )
+    router=search_routes.router,
+    prefix="/search",
+    dependencies=[Depends(verify_api_key)]  
+)
 
 
 def main():

--- a/lettuce/tests/unit/test_api_auth.py
+++ b/lettuce/tests/unit/test_api_auth.py
@@ -1,0 +1,63 @@
+import os
+import pytest 
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from api import app 
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_generate_events():
+    async def simple_mock(request):
+        yield '{"event": "test", "data": "mocked"}'
+    
+    with patch('routers.pipeline_routes.generate_events', side_effect=simple_mock) as mock:
+        yield mock
+
+
+class TestAuthentication:
+    
+    def test_missing_authorization_header(self, mock_generate_events):
+        """Test request without Authorization header"""
+        response = client.post(
+            "/pipeline/", 
+            json={"names": ["Betnovate Scalp Application", "Panadol"]}
+        )
+        
+        assert response.status_code in [401, 403]  
+    
+    def test_invalid_authorization_format(self, mock_generate_events):
+        """Test malformed Authorization header"""
+        headers = {"Authorization": "InvalidFormat token123"}
+        response = client.post(
+            "/pipeline/", 
+            headers=headers
+        )
+        
+        assert response.status_code == 403
+    
+    def test_invalid_api_key(self, mock_generate_events):
+        """Test with wrong API key"""
+        headers = {"Authorization": "Bearer wrong_key"}
+        response = client.post(
+            "/pipeline/", 
+            headers=headers
+        )
+        
+        assert response.status_code == 401
+        assert "Invalid API key" in response.json()["detail"]
+    
+    @patch.dict(os.environ, {"AUTH_API_KEY": "test_key_123"})
+    def test_valid_api_key(self, mock_generate_events):
+        """Test with correct API key"""
+
+        headers = {"Authorization": "Bearer test_key_123"}
+        response = client.post(
+            "/pipeline/", 
+            json={"names": ["test"]},
+            headers=headers
+        )
+        assert response.status_code == 200

--- a/lettuce/tests/unit/test_api_auth.py
+++ b/lettuce/tests/unit/test_api_auth.py
@@ -38,7 +38,8 @@ class TestAuthentication:
         )
         
         assert response.status_code == 403
-    
+
+    @patch.dict(os.environ, {"AUTH_API_KEY": "test_key_123"}) 
     def test_invalid_api_key(self, mock_generate_events):
         """Test with wrong API key"""
         headers = {"Authorization": "Bearer wrong_key"}

--- a/lettuce/uv.lock
+++ b/lettuce/uv.lock
@@ -756,7 +756,7 @@ requires-dist = [
     { name = "fastembed-haystack", specifier = ">=1.2.0" },
     { name = "haystack-ai", specifier = ">=2.7.0" },
     { name = "huggingface-hub", specifier = ">=0.24.6" },
-    { name = "llama-cpp-haystack", specifier = ">=0.4.1" },
+    { name = "llama-cpp-haystack", specifier = ">=0.4.1,<=0.4.4" },
     { name = "llama-cpp-python", specifier = ">=0.2.89" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "pandas", specifier = ">=2.1.0" },
@@ -779,15 +779,15 @@ provides-extras = ["test", "streamlit"]
 
 [[package]]
 name = "llama-cpp-haystack"
-version = "1.0.0"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "haystack-ai" },
     { name = "llama-cpp-python" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/44/e2bce0a16ec272ad911e5635370769d5416950d05e6d14be464b0ff0c739/llama_cpp_haystack-1.0.0.tar.gz", hash = "sha256:55a4988860d05e612291c26eab7ce783a412d7665399dad88364a7edd9af6b19", size = 20048 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/3b/5e0c05591c701ad4a8134aeb7df4574936e7d9c917999dd028e42299ff82/llama_cpp_haystack-0.4.4.tar.gz", hash = "sha256:e30a7e3e9a74d2e8a337d1a8c77d8a1256bd9a0510c65651d03c2ed7dcc08a8e", size = 18437 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/20/ff7ef1f42f7114217a958f202b83e3b2846b44e94338aaac6098faa706a7/llama_cpp_haystack-1.0.0-py3-none-any.whl", hash = "sha256:4b90fdf97a72d7628222ea5a6985ac5761088707909b992239f62873921c1255", size = 13410 },
+    { url = "https://files.pythonhosted.org/packages/0d/5a/09cc8f7e0eca0525eda17ab818fbb7d0bb78d8fe67d7bc42b089ce92f65b/llama_cpp_haystack-0.4.4-py3-none-any.whl", hash = "sha256:cf7934ce6266e4465b4ef1cc8dba9c2fbe2e7b81c69f0d00782b13d5a87966f9", size = 12291 },
 ]
 
 [[package]]


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
For deployment of lettuce to production environments we need some form of user authentication to control who is allowed to send requests to the lettuce server. To implement this I have
- Added `verify_api_key` function to `app.py` entrypoint which extracts API_KEY from `.env` file and validates it 
- Added this as a dependency to the two endpoint routes 

## Related Issues or other material
Related #149
Closes #149 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [] This PR contains relevant tests 