### PR TITLE
Optimisation/vector query

### DIFF
--- a/lettuce/omop/omop_models.py
+++ b/lettuce/omop/omop_models.py
@@ -2,6 +2,7 @@ from sqlalchemy.dialects.postgresql.types import TSVECTOR
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy import DATE, Column, Date, Integer, String
 from pgvector.sqlalchemy import Vector
+from sqlalchemy.ext.hybrid import hybrid_method
 
 from os import environ
 
@@ -98,3 +99,7 @@ class Embedding(Base):
     concept_id = Column(Integer)
     embedding = mapped_column(Vector(DB_VECSIZE))
     dummy_primary = Column(Integer, primary_key=True)
+
+    @hybrid_method
+    def score(self, query_embedding):
+        return self.embedding.cosine_distance(query_embedding)

--- a/lettuce/omop/omop_queries.py
+++ b/lettuce/omop/omop_queries.py
@@ -369,31 +369,40 @@ def query_vector(
         n: int = 5,
         describe_concept:bool = False,
         ) -> Select:
+    filtered_concepts = select(Concept.concept_id)
+    if embed_vocab is not None:
+        filtered_concepts = filtered_concepts.where(Concept.vocabulary_id.in_(embed_vocab))
+    if domain_id is not None:
+        filtered_concepts = filtered_concepts.where(Concept.domain_id.in_(domain_id))
+    if standard_concept:
+        filtered_concepts = filtered_concepts.where(Concept.standard_concept == "S")
+    if valid_concept:
+        filtered_concepts = filtered_concepts.where(Concept.invalid_reason == None)
+
+    score_expr = Embedding.score(query_embedding).label("score")
+    
+    embedding_scores = (
+            select(Embedding.concept_id, score_expr)
+            .where(Embedding.concept_id.in_(filtered_concepts))
+            .order_by(score_expr)
+            .limit(n)
+            .cte("embedding_result")
+        )
+
+
     if describe_concept:
         query = (
-            select(Concept, Embedding.embedding.cosine_distance(query_embedding).label("score"))
-            .join(Embedding, Concept.concept_id == Embedding.concept_id)
-            .order_by(Embedding.embedding.cosine_distance(query_embedding))
-            .limit(n)
+            select(Concept, embedding_scores.c.score)
+            .join(Concept, Concept.concept_id == embedding_scores.c.concept_id)
         )
     else:
         query = (
             select(
                 Concept.concept_id.label("id"),
                 Concept.concept_name.label("content"),
-                Embedding.embedding.cosine_distance(query_embedding).label("score"),
+                embedding_scores.c.score,
             )
-            .join(Embedding, Concept.concept_id == Embedding.concept_id)
-            .order_by(Embedding.embedding.cosine_distance(query_embedding))
-            .limit(n)
+            .join(Concept, Concept.concept_id == embedding_scores.c.concept_id)
         )
-    if embed_vocab is not None:
-        query = query.where(Concept.vocabulary_id.in_(embed_vocab))
-    if domain_id is not None:
-        query = query.where(Concept.domain_id.in_(domain_id))
-    if standard_concept:
-        query = query.where(Concept.standard_concept == "S")
-    if valid_concept:
-        query = query.where(Concept.invalid_reason == None)
-
+    
     return query

--- a/lettuce/tests/unit/test_embeddings.py
+++ b/lettuce/tests/unit/test_embeddings.py
@@ -4,12 +4,11 @@ from unittest.mock import Mock
 import pytest
 from haystack.dataclasses import Document
 from sqlalchemy.orm import Session
+from components.embeddings import PGVectorQuery
 
 pytestmark = pytest.mark.skipif(
     os.getenv("SKIP_DATABASE_TESTS") == "true", reason="Skipping database tests"
 )
-
-from components.embeddings import PGVectorQuery
 
 
 class TestPGVectorQuery:
@@ -86,6 +85,9 @@ class TestPGVectorQuery:
 
         # Test with different top_k values
         for k in [1, 3, 5]:
+            # Mock the results to return only k items
+            mock_execute.mappings.return_value.all.return_value = mock_results[:k]
+            
             query_component = PGVectorQuery(connection=mock_session, top_k=k)
             result = query_component.run(query_embedding=query_embedding)
             assert len(result["documents"]) == k

--- a/lettuce/tests/unit/test_embeddings.py
+++ b/lettuce/tests/unit/test_embeddings.py
@@ -82,17 +82,6 @@ class TestPGVectorQuery:
         mock_execute.mappings.return_value.all.return_value = mock_results
         mock_session.execute.return_value = mock_execute
 
-        # Verifies that LIMIT is set correctly
-        def execute_side_effect(query):
-            assert query._limit_clause.value == k
-            mock_execute = Mock()
-            mock_execute.mappings.return_value.all.return_value = mock_results[
-                : query._limit_clause.value
-            ]
-            return mock_execute
-
-        mock_session.execute.side_effect = execute_side_effect
-
         query_embedding = [0.1, 0.2, 0.3]
 
         # Test with different top_k values


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
♻️ Refactor
⚡️ Optimization

## PR Description
OK, so the query I had in before is slow. This one can be faster. It creates a CTE for embeddings, filtered by whatever criteria the user defines. Then this is joined to the concept table. The previous one joined the whole embeddings table to the whole concept table, then ranked concepts, then filtered them. Slower, took up more memory.

## Related Issues or other material
Related #158 
Closes #158 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [X] This PR contains relevant tests / Or doesn't need to per the below explanation
