### PR TITLE
Added more aggressive cleanup of disk space on the runner

### DIFF
--- a/.github/workflows/release.dev-weights.yml
+++ b/.github/workflows/release.dev-weights.yml
@@ -7,7 +7,7 @@ name: Build and publish pre-loaded weights image to GHCR and deploy to Azure
 on:
   push:
     branches:
-      - bugfix/fix-docker-image-build-on-cicd-pipeline
+      - main
         
 env:
   image-name: lettuce

--- a/.github/workflows/release.dev-weights.yml
+++ b/.github/workflows/release.dev-weights.yml
@@ -7,7 +7,7 @@ name: Build and publish pre-loaded weights image to GHCR and deploy to Azure
 on:
   push:
     branches:
-      - main
+      - bugfix/fix-docker-image-build-on-cicd-pipeline
         
 env:
   image-name: lettuce
@@ -26,14 +26,16 @@ jobs:
       image-sha: ${{ steps.tag.outputs.image_sha }}
 
     steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android  
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker system prune -af
-          df -h
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false  # Keep false since Docker needed
+          swap-storage: true
+          tool-cache: true  # Saves ~6GB but removes Node, Python, etc.
 
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
The cicd build for the docker image with weights was failing due to the fact the image size is now 11.4gb. The quickest way around this is to free up more size on the runner itself with a more aggressive clean up of unnecessary packages at the beginning of the workflow. I have added a new github actions step in order to do this. 

## Related Issues or other material
Related #
Closes #

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [] This PR contains relevant tests / Or doesn't need to per the below explanation