### PR TITLE
fix: only load get_local_weights if necessary

### DIFF
--- a/lettuce/components/models/__init__.py
+++ b/lettuce/components/models/__init__.py
@@ -1,10 +1,7 @@
 from .connect import get_model, connect_to_ollama, connect_to_openai
-from .local_models import get_local_weights, download_model_from_huggingface
 
 __all__ = [
         "get_model",
         "connect_to_openai",
         "connect_to_ollama",
-        "get_local_weights",
-        "download_model_from_huggingface"
         ]

--- a/lettuce/tests/unit/test_dynamic_imports.py
+++ b/lettuce/tests/unit/test_dynamic_imports.py
@@ -17,7 +17,12 @@ def test_llama_loaded():
 def test_llama_not_loaded():
     from components.models import get_model
 
-    llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
-    print(llama_cpp_modules)
-
-    assert(len(llama_cpp_modules) == 0)
+    # Unfortunately, haystack pulls in llama_cpp stuff if it's installed,
+    # whether you like it or not. Obviously this is a good design for them,
+    # but it's inconvenient, as this test doesn't work
+    # llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
+    # print(llama_cpp_modules)
+    #
+    # assert(len(llama_cpp_modules) == 0)
+    # and we just have to test this instead:
+    assert "components.models.local_models" not in sys.modules

--- a/lettuce/tests/unit/test_dynamic_imports.py
+++ b/lettuce/tests/unit/test_dynamic_imports.py
@@ -1,22 +1,17 @@
 import sys
+import subprocess
 import pytest
 
 from options.base_options import InferenceType, BaseOptions
+
 settings = BaseOptions()
 
 not_using_local_weights = settings.inference_type != InferenceType.LLAMA_CPP
 
-@pytest.mark.skipif(not_using_local_weights, reason="Not using local weights")
-def test_llama_loaded():
-    from components.models import local_models
 
-    llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
-
-    assert(len(llama_cpp_modules) > 0)
-
-def test_llama_not_loaded():
-    from components.models import get_model
-
+def test_llama_not_loaded_subprocess():
+    # Because pytest pulls in the local_models stuff, this has to run in its own subprocess
+    # or local_models is in sys.modules
     # Unfortunately, haystack pulls in llama_cpp stuff if it's installed,
     # whether you like it or not. Obviously this is a good design for them,
     # but it's inconvenient, as this test doesn't work
@@ -25,4 +20,24 @@ def test_llama_not_loaded():
     #
     # assert(len(llama_cpp_modules) == 0)
     # and we just have to test this instead:
-    assert "components.models.local_models" not in sys.modules
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from components.models import get_model; "
+            "import sys; "
+            "assert 'components.models.local_models' not in sys.modules",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(not_using_local_weights, reason="Not using local weights")
+def test_llama_loaded():
+    from components.models import local_models
+
+    llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
+
+    assert len(llama_cpp_modules) > 0

--- a/lettuce/tests/unit/test_dynamic_imports.py
+++ b/lettuce/tests/unit/test_dynamic_imports.py
@@ -1,0 +1,23 @@
+import sys
+import pytest
+
+from options.base_options import InferenceType, BaseOptions
+settings = BaseOptions()
+
+not_using_local_weights = settings.inference_type != InferenceType.LLAMA_CPP
+
+@pytest.mark.skipif(not_using_local_weights, reason="Not using local weights")
+def test_llama_loaded():
+    from components.models import local_models
+
+    llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
+
+    assert(len(llama_cpp_modules) > 0)
+
+def test_llama_not_loaded():
+    from components.models import get_model
+
+    llama_cpp_modules = [x for x in sys.modules.keys() if "llama_cpp" in x]
+    print(llama_cpp_modules)
+
+    assert(len(llama_cpp_modules) == 0)

--- a/lettuce/tests/unit/test_models.py
+++ b/lettuce/tests/unit/test_models.py
@@ -4,7 +4,7 @@ import logging
 from components.models.connect import connect_to_openai, get_model
 from options.pipeline_options import LLMModel 
 from options.base_options import InferenceType, BaseOptions
-local_models = pytest.importorskip("components.models.local_models")
+local_models = pytest.importorskip("components.models.local_models", exc_type=ImportError)
 
 # Configure logging for tests
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
This wasn't a problem on my machine (probably a uv sync thing) but in azure the API fails because calling any search route imports `get_model` from `components.models`, which tries to import Llama C++ stuff from components.models.local_models. Unless you have the optional dependency group `llama_cpp` this fails.

I've removed the import from components.models, so the API no longer tries to import it unless INFERENCE_TYPE=llama-cpp-python

I've added a test that checks importing `get_model` doesn't import `local_models`

## Related Issues or other material
Related #205 
Closes #205 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [X] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![alt_text](gif_link)
