### PR TITLE
fix: container uses llama_cpp

### DIFF
--- a/lettuce/Dockerfile
+++ b/lettuce/Dockerfile
@@ -7,9 +7,7 @@ ENV UV_CACHE_DIR=/tmp/uv_cache \
 WORKDIR /src
 COPY pyproject.toml ./
 RUN uv sync --no-dev --extra azure\
-    && rm -rf /tmp/uv_cache ~/.cache/pip \
-    && uv pip uninstall torch \
-    && uv pip install torch==2.7.1+cpu --index-url https://download.pytorch.org/whl/cpu
+    && rm -rf /tmp/uv_cache ~/.cache/pip
 
 # Runtime stage 
 FROM python:3.12-slim-bookworm
@@ -17,7 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \ 
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/src/.venv/bin:$PATH"
-ENV INFERENCE_TYPE="llama-cpp-python"
 WORKDIR /src
 COPY --from=builder /src/.venv /src/.venv
 


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix


## PR Description
I fixed the code, but not the container, which now tries to use INFERENCE_TYPE=llama-cpp-python without installing llama-cpp-python. Or rather, now it doesn't.

## Related Issues or other material
Related #205 
Closes #205

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [X] This PR contains relevant tests / Or doesn't need to per the below explanation

Container now builds and server starts on my machine
